### PR TITLE
Recipes for openexif

### DIFF
--- a/openexif/build.sh
+++ b/openexif/build.sh
@@ -1,0 +1,5 @@
+./configure \\
+  --prefix=$PREFIX
+
+VERBOSE=1 ./make
+make install

--- a/openexif/meta.yaml
+++ b/openexif/meta.yaml
@@ -1,0 +1,19 @@
+package:
+  name: openexif
+  version: 2.1.4
+
+source:
+  fn: openexif-2_1_4-src.zip
+  url: http://downloads.sourceforge.net/project/openexif/openexif/2.1.4/openexif-2_1_4-src.zip?r=http%3A%2F%2Fsourceforge.net%2Fprojects%2Fopenexif%2Ffiles%2Fopenexif%2F2.1.4%2F&ts=1454967266&use_mirror=freefr
+
+requirements:
+  build:
+
+
+build:
+  number: 0
+
+about:
+  home: http://openexif.sourceforge.net/
+  summary: An Exif file is a JPEG image file with additional application segments which can contain tags with metadata (additional data of the image), a thumbnail, a screennail, audio data, etc.
+  license: BSD


### PR DESCRIPTION
Voilà la recette pour le package openexif. J'ai un problème au moment de compiler sur le Vagrant (**conda build**) : 
`/home/vagrant/code/sed-pro-inria/conda-recipes/openexif/build.sh: line 1: ./configure: Permission denied`
J'ai télechargé en local les sources et ça fonctionne bien (le ./configure s'execute sans problèmes). J'ai une doute aussi sur l'url pour le télechargement du code car dans mon ordi ça n'a pas marché avec wget. Mais au moment de faire **conda build** il télécharge les bonnes sources...  Si vous avez des idées, je suis preneur !